### PR TITLE
optimize sparse polynomial evaluation by relying more on sparsity

### DIFF
--- a/src/data_structures/impl_ml_extension.rs
+++ b/src/data_structures/impl_ml_extension.rs
@@ -357,7 +357,7 @@ impl<F: Field> MLExtension<F> for SparseMLExtensionMap<F> {
         }
     }
 
-    /// runtime: O(n) where n is the size of matrix
+    /// runtime: O(nlogN): n is number of non-zero entries and N is size of matrix
     fn eval_at(&self, point: &[F]) -> Result<F, Self::Error> {
         let mut dp = self._partial_eval(point)?;
 


### PR DESCRIPTION
Inspired by XZZPS19 (page16), this PR tries to optimize the runtime for sparse polynomial by relying more on sparsity. 

The algorithm in paper is slightly modified so that the program will not generate a `precompute` table that is too large. 
- split the evaluation point into vectors of size 8
- for each vector, calculate the `precompute` table as described in the paper
- partially evaluate the result table on the first 8 polynomial arguments, relying on sparsity

**We can expect a significant improvement in the runtime of evaluating a sparse polynomial.**