### PR TITLE
support initial vector input and subclaim output by prover

### DIFF
--- a/src/ml_sumcheck/t13/verifier.rs
+++ b/src/ml_sumcheck/t13/verifier.rs
@@ -146,7 +146,7 @@ impl<F: Field, R: RnFg<F> + FeedableRNG> Protocol for MLLibraVerifier<F, R> {
     }
 }
 
-fn interpolate_deg_n_poly<F: Field>(p_i: &[F], eval_at: F) -> F {
+pub(crate) fn interpolate_deg_n_poly<F: Field>(p_i: &[F], eval_at: F) -> F {
     let mut result = F::zero();
     let mut i = F::zero();
     for term in p_i.iter() {


### PR DESCRIPTION
For `MLSumcheck`
- When generating the proof, user can specify the initial vector used by the Blake2s random oracle. 
- Prover can have access to the subclaim now. 