### PR TITLE
Silence clippy warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - [\#55](https://github.com/arkworks-rs/sumcheck/pull/55) Improve the interpolation performance and avoid unnecessary state clones.
 
 ### Bug fixes
+## v0.4.0
+- Change dependency to version `0.4.0` of other arkworks-rs crates.
 
 ## v0.3.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ edition = "2018"
 resolver = "2"
 
 [dependencies]
-ark-ff = { version = "^0.3.0", default-features = false }
-ark-serialize = { version = "^0.3.0", default-features = false, features = ["derive"] }
-ark-std = { version = "^0.3.0", default-features = false }
-ark-poly = { version = "^0.3.0", default-features = false }
+ark-ff = { version = "0.4.0", default-features = false }
+ark-serialize = { version = "0.4.0", default-features = false, features = ["derive"] }
+ark-std = { version = "0.4.0", default-features = false }
+ark-poly = { version = "0.4.0", default-features = false }
 blake2 = { version = "0.9", default-features = false }
 hashbrown = { version = "0.13.1" }
 rayon = { version = "1", optional = true }
 
 [dev-dependencies]
-ark-test-curves = { version = "^0.3.0", default-features = false, features = ["bls12_381_scalar_field", "bls12_381_curve"] }
+ark-test-curves = { version = "0.4.0", default-features = false, features = ["bls12_381_scalar_field", "bls12_381_curve"] }
 
 [profile.release]
 opt-level = 3

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,7 +22,7 @@ impl fmt::Display for Error {
         if let Self::OtherError(s) = self {
             f.write_str(s)
         } else {
-            f.write_fmt(format_args!("{:?}", self))
+            f.write_fmt(format_args!("{self:?}"))
         }
     }
 }

--- a/src/gkr_round_sumcheck/data_structures.rs
+++ b/src/gkr_round_sumcheck/data_structures.rs
@@ -47,13 +47,12 @@ impl<F: Field> GKRRoundSumcheckSubClaim<F> {
         let guv: Vec<_> = g
             .iter()
             .chain(self.u.iter())
-            .chain(self.v.iter())
-            .map(|x| *x)
+            .chain(self.v.iter()).copied()
             .collect();
         let actual_evaluation = f1.evaluate(&guv).unwrap()
             * &f2.evaluate(&self.u).unwrap()
             * &f3.evaluate(&self.v).unwrap();
 
-        return actual_evaluation == self.expected_evaluation;
+        actual_evaluation == self.expected_evaluation
     }
 }

--- a/src/gkr_round_sumcheck/data_structures.rs
+++ b/src/gkr_round_sumcheck/data_structures.rs
@@ -50,8 +50,8 @@ impl<F: Field> GKRRoundSumcheckSubClaim<F> {
             .chain(self.v.iter()).copied()
             .collect();
         let actual_evaluation = f1.evaluate(&guv).unwrap()
-            * &f2.evaluate(&self.u).unwrap()
-            * &f3.evaluate(&self.v).unwrap();
+            * f2.evaluate(&self.u).unwrap()
+            * f3.evaluate(&self.v).unwrap();
 
         actual_evaluation == self.expected_evaluation
     }

--- a/src/ml_sumcheck/data_structures.rs
+++ b/src/ml_sumcheck/data_structures.rs
@@ -75,7 +75,7 @@ impl<F: Field> ListOfProductsOfPolynomials<F> {
     ) {
         let product: Vec<Rc<DenseMultilinearExtension<F>>> = product.into_iter().collect();
         let mut indexed_product = Vec::with_capacity(product.len());
-        assert!(product.len() > 0);
+        assert!(!product.is_empty());
         self.max_multiplicands = max(self.max_multiplicands, product.len());
         for m in product {
             assert_eq!(

--- a/src/ml_sumcheck/mod.rs
+++ b/src/ml_sumcheck/mod.rs
@@ -43,7 +43,7 @@ impl<F: Field> MLSumcheck<F> {
         let mut fs_rng = Blake2s512Rng::setup();
         fs_rng.feed(&polynomial.info())?;
 
-        let mut prover_state = IPForMLSumcheck::prover_init(&polynomial);
+        let mut prover_state = IPForMLSumcheck::prover_init(polynomial);
         let mut verifier_msg = None;
         let mut prover_msgs = Vec::with_capacity(polynomial.num_variables);
         for _ in 0..polynomial.num_variables {
@@ -75,9 +75,9 @@ impl<F: Field> MLSumcheck<F> {
             );
         }
 
-        Ok(IPForMLSumcheck::check_and_generate_subclaim(
+        IPForMLSumcheck::check_and_generate_subclaim(
             verifier_state,
             claimed_sum,
-        )?)
+        )
     }
 }

--- a/src/ml_sumcheck/protocol/prover.rs
+++ b/src/ml_sumcheck/protocol/prover.rs
@@ -82,10 +82,8 @@ impl<F: Field> IPForMLSumcheck<F> {
             for multiplicand in prover_state.flattened_ml_extensions.iter_mut() {
                 *multiplicand = multiplicand.fix_variables(&[r]);
             }
-        } else {
-            if prover_state.round > 0 {
-                panic!("verifier message is empty");
-            }
+        } else if prover_state.round > 0 {
+            panic!("verifier message is empty");
         }
 
         prover_state.round += 1;

--- a/src/ml_sumcheck/protocol/prover.rs
+++ b/src/ml_sumcheck/protocol/prover.rs
@@ -102,17 +102,16 @@ impl<F: Field> IPForMLSumcheck<F> {
         // generate sum
         for b in 0..1 << (nv - i) {
             let mut t_as_field = F::zero();
-            for t in 0..degree + 1 {
-                // evaluate P_round(t)
+            for old_product in products_sum.iter_mut().take(degree + 1) {
                 for (coefficient, products) in &prover_state.list_of_products {
                     let num_multiplicands = products.len();
                     let mut product = *coefficient;
-                    for j in 0..num_multiplicands {
-                        let table = &prover_state.flattened_ml_extensions[products[j]]; // j's range is checked in init
+                    for jth_product in products.iter().take(num_multiplicands) {
+                        let table = &prover_state.flattened_ml_extensions[*jth_product]; 
                         product *= table[b << 1] * (F::one() - t_as_field)
                             + table[(b << 1) + 1] * t_as_field;
                     }
-                    products_sum[t] += product;
+                    *old_product += product;
                 }
                 t_as_field += F::one();
             }

--- a/src/ml_sumcheck/protocol/verifier.rs
+++ b/src/ml_sumcheck/protocol/verifier.rs
@@ -114,10 +114,10 @@ impl<F: Field> IPForMLSumcheck<F> {
             expected = interpolate_uni_poly(evaluations, verifier_state.randomness[i]);
         }
 
-        return Ok(SubClaim {
+        Ok(SubClaim {
             point: verifier_state.randomness,
             expected_evaluation: expected,
-        });
+        })
     }
 
     /// simulate a verifier message without doing verification

--- a/src/ml_sumcheck/test.rs
+++ b/src/ml_sumcheck/test.rs
@@ -31,13 +31,13 @@ fn random_product<F: Field, R: RngCore>(
         sum += product;
     }
 
-    return (
+    (
         multiplicands
             .into_iter()
             .map(|x| Rc::new(DenseMultilinearExtension::from_evaluations_vec(nv, x)))
             .collect(),
         sum,
-    );
+    )
 }
 
 fn random_list_of_products<F: Field, R: RngCore>(

--- a/src/ml_sumcheck/test.rs
+++ b/src/ml_sumcheck/test.rs
@@ -23,9 +23,9 @@ fn random_product<F: Field, R: RngCore>(
 
     for _ in 0..(1 << nv) {
         let mut product = F::one();
-        for i in 0..num_multiplicands {
+        for multiplicand in &mut multiplicands {
             let val = F::rand(rng);
-            multiplicands[i].push(val);
+            multiplicand.push(val);
             product *= val;
         }
         sum += product;


### PR DESCRIPTION
Assuming the dependency update gets merged, this pull request makes slight mods to make clippy happy. Fixes #67 

- update dependencies to version 0.4.0 of other arkworks-rs crates.
- cargo clippy --fix
- indexing to iterators in protocol
- remove unnecessary references