### PR TITLE
Performance: parallelize prover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Improvements
 
+- [\#72](https://github.com/arkworks-rs/sumcheck/pull/72) Uses `rayon` in the prover when the `parallel` feature is enabled.
+
 - [\#71](https://github.com/arkworks-rs/sumcheck/pull/71) Improve prover performance by using an arithmetic sequence rather than interpolation inside of the `prove_round` loop.
 
 - [\#55](https://github.com/arkworks-rs/sumcheck/pull/55) Improve the interpolation performance and avoid unnecessary state clones.

--- a/src/ml_sumcheck/protocol/prover.rs
+++ b/src/ml_sumcheck/protocol/prover.rs
@@ -106,8 +106,6 @@ impl<F: Field> IPForMLSumcheck<F> {
         let fold_result = ark_std::cfg_into_iter!((0..1 << (nv - i)), 1 << 10).fold(
             zeros,
             |(mut products_sum, mut product), b| {
-                // `scratch.0` is the running sum in this fold.
-                // `scratch.1` is a scratch vector that is only used inside this lambda
                 for (coefficient, products) in &prover_state.list_of_products {
                     product.fill(*coefficient);
                     for &jth_product in products {

--- a/src/ml_sumcheck/protocol/prover.rs
+++ b/src/ml_sumcheck/protocol/prover.rs
@@ -103,7 +103,7 @@ impl<F: Field> IPForMLSumcheck<F> {
         #[cfg(feature = "parallel")]
         let zeros = || (vec![F::zero(); degree + 1], vec![F::zero(); degree + 1]);
 
-        let fold_result = ark_std::cfg_into_iter!((0..1 << (nv - i)), 1 << 10).fold(
+        let fold_result = ark_std::cfg_into_iter!(0..1 << (nv - i), 1 << 10).fold(
             zeros,
             |(mut products_sum, mut product), b| {
                 for (coefficient, products) in &prover_state.list_of_products {

--- a/src/ml_sumcheck/protocol/prover.rs
+++ b/src/ml_sumcheck/protocol/prover.rs
@@ -5,7 +5,7 @@ use crate::ml_sumcheck::protocol::IPForMLSumcheck;
 use ark_ff::Field;
 use ark_poly::{DenseMultilinearExtension, MultilinearExtension};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::vec::Vec;
+use ark_std::{cfg_iter_mut, vec::Vec};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
@@ -81,11 +81,7 @@ impl<F: Field> IPForMLSumcheck<F> {
             // fix argument
             let i = prover_state.round;
             let r = prover_state.randomness[i - 1];
-            #[cfg(not(feature = "parallel"))]
-            let iter_mut = prover_state.flattened_ml_extensions.iter_mut();
-            #[cfg(feature = "parallel")]
-            let iter_mut = prover_state.flattened_ml_extensions.par_iter_mut();
-            iter_mut.for_each(|multiplicand| {
+            cfg_iter_mut!(prover_state.flattened_ml_extensions).for_each(|multiplicand| {
                 *multiplicand = multiplicand.fix_variables(&[r]);
             });
         } else if prover_state.round > 0 {

--- a/src/ml_sumcheck/protocol/prover.rs
+++ b/src/ml_sumcheck/protocol/prover.rs
@@ -103,6 +103,8 @@ impl<F: Field> IPForMLSumcheck<F> {
         #[cfg(feature = "parallel")]
         let zeros = || (vec![F::zero(); degree + 1], vec![F::zero(); degree + 1]);
 
+        // generate sum
+
         let fold_result = ark_std::cfg_into_iter!(0..1 << (nv - i), 1 << 10).fold(
             zeros,
             |(mut products_sum, mut product), b| {

--- a/src/ml_sumcheck/protocol/prover.rs
+++ b/src/ml_sumcheck/protocol/prover.rs
@@ -81,9 +81,13 @@ impl<F: Field> IPForMLSumcheck<F> {
             // fix argument
             let i = prover_state.round;
             let r = prover_state.randomness[i - 1];
-            for multiplicand in prover_state.flattened_ml_extensions.iter_mut() {
+            #[cfg(not(feature = "parallel"))]
+            let iter_mut = prover_state.flattened_ml_extensions.iter_mut();
+            #[cfg(feature = "parallel")]
+            let iter_mut = prover_state.flattened_ml_extensions.par_iter_mut();
+            iter_mut.for_each(|multiplicand| {
                 *multiplicand = multiplicand.fix_variables(&[r]);
-            }
+            });
         } else if prover_state.round > 0 {
             panic!("verifier message is empty");
         }

--- a/src/ml_sumcheck/protocol/prover.rs
+++ b/src/ml_sumcheck/protocol/prover.rs
@@ -103,10 +103,9 @@ impl<F: Field> IPForMLSumcheck<F> {
         #[cfg(feature = "parallel")]
         let zeros = || (vec![F::zero(); degree + 1], vec![F::zero(); degree + 1]);
 
-        let fold_result =
-            ark_std::cfg_into_iter!((0..1 << (nv - i)), 1 << 10).fold(zeros, |mut scratch, b| {
-                let products_sum = &mut scratch.0;
-                let product = &mut scratch.1;
+        let fold_result = ark_std::cfg_into_iter!((0..1 << (nv - i)), 1 << 10).fold(
+            zeros,
+            |(mut products_sum, mut product), b| {
                 // `scratch.0` is the running sum in this fold.
                 // `scratch.1` is a scratch vector that is only used inside this lambda
                 for (coefficient, products) in &prover_state.list_of_products {
@@ -124,8 +123,9 @@ impl<F: Field> IPForMLSumcheck<F> {
                         products_sum[t] += product[t];
                     }
                 }
-                scratch
-            });
+                (products_sum, product)
+            },
+        );
 
         #[cfg(not(feature = "parallel"))]
         let products_sum = fold_result.0;

--- a/src/ml_sumcheck/protocol/prover.rs
+++ b/src/ml_sumcheck/protocol/prover.rs
@@ -105,21 +105,23 @@ impl<F: Field> IPForMLSumcheck<F> {
 
         let fold_result =
             ark_std::cfg_into_iter!((0..1 << (nv - i)), 1 << 10).fold(zeros, |mut scratch, b| {
+                let products_sum = &mut scratch.0;
+                let product = &mut scratch.1;
                 // `scratch.0` is the running sum in this fold.
                 // `scratch.1` is a scratch vector that is only used inside this lambda
                 for (coefficient, products) in &prover_state.list_of_products {
-                    scratch.1.fill(*coefficient);
+                    product.fill(*coefficient);
                     for &jth_product in products {
                         let table = &prover_state.flattened_ml_extensions[jth_product];
                         let mut start = table[b << 1];
                         let step = table[(b << 1) + 1] - start;
-                        for p in scratch.1.iter_mut() {
+                        for p in product.iter_mut() {
                             *p *= start;
                             start += step;
                         }
                     }
                     for t in 0..degree + 1 {
-                        scratch.0[t] += (&mut scratch.1)[t];
+                        products_sum[t] += product[t];
                     }
                 }
                 scratch


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

The outer loop of computing the sum as well as fixing the variables in `prove_round` inside the prover is modified to use rayon parallelization. This is only enabled when the `parallel` feature is enabled.

On my machine (4 physical, 8 logical), using `parallel` gives a bit over 4x speedup on proof creation.

Note: the CI doesn't run `cargo test --features parallel`, but I did locally, and it passes.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] ~Linked to Github issue with discussion and accepted design OR~ have an explanation in the PR that describes this work.
- [x] ~Wrote unit tests~ - This is simply a rewrite of a loop, no functionality has changed.
- [ ] Updated relevant documentation in the code - I'm not sure what should be updated here.
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer