### PR TITLE
Feature: add support for using `MLSumcheck` as subprotocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Improvements
 
+- [\#73](https://github.com/arkworks-rs/sumcheck/pull/73) Add support for using `MLSumcheck` as subprotocol.
+
 - [\#72](https://github.com/arkworks-rs/sumcheck/pull/72) Uses `rayon` in the prover when the `parallel` feature is enabled.
 
 - [\#71](https://github.com/arkworks-rs/sumcheck/pull/71) Improve prover performance by using an arithmetic sequence rather than interpolation inside of the `prove_round` loop.

--- a/src/ml_sumcheck/protocol/prover.rs
+++ b/src/ml_sumcheck/protocol/prover.rs
@@ -24,9 +24,12 @@ pub struct ProverState<F: Field> {
     pub list_of_products: Vec<(F, Vec<usize>)>,
     /// Stores a list of multilinear extensions in which `self.list_of_products` points to
     pub flattened_ml_extensions: Vec<DenseMultilinearExtension<F>>,
-    num_vars: usize,
-    max_multiplicands: usize,
-    round: usize,
+    /// Number of variables
+    pub num_vars: usize,
+    /// Max number of multiplicands in a product
+    pub max_multiplicands: usize,
+    /// The current round number
+    pub round: usize,
 }
 
 impl<F: Field> IPForMLSumcheck<F> {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Some protocols use sumcheck as a subprotocol. Two components in `MLSumcheck` that don't enable this well are:
* The rng is not linked to the broader protocol. (i.e., the transcript begins and ends within sumcheck). This is part of what #54 is trying to solve.
* The prover's state is not accessible after the prover runs. This is mentioned in #64.

This PR adds `prove_as_subprotocol` and `verify_as_subprotocol` functions to `MLSumcheck`. As a result, this is not a breaking change. (Although I don't see the utility of the existing `verify` and `prove` functions.)

Note: I did not use [Sponge](https://github.com/arkworks-rs/crypto-primitives/blob/main/src/sponge/mod.rs) since it's on 0.3.0, and seems to be a WIP.

Finally, some tests around this are added/improved.

closes: #64 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer