### PR TITLE
Interpolation function of the ML sumcheck verifier corrected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - [\#55](https://github.com/arkworks-rs/sumcheck/pull/55) Improve the interpolation performance and avoid unnecessary state clones.
 
 ### Bug fixes
+
+- [\#75](https://github.com/arkworks-rs/sumcheck/pull/75) Correct interpolation function in the verifier
+
 ## v0.4.0
 - Change dependency to version `0.4.0` of other arkworks-rs crates.
 

--- a/src/ml_sumcheck/protocol/verifier.rs
+++ b/src/ml_sumcheck/protocol/verifier.rs
@@ -144,7 +144,7 @@ pub(crate) fn interpolate_uni_poly<F: Field>(p_i: &[F], eval_at: F) -> F {
     evals.push(eval_at);
 
     //`prod = \prod_{j} (eval_at - j)`
-    // we return early if 0 <= eval_at <  len
+    // we return early if 0 <= eval_at <  len, i.e. if the desired value has been passed
     let mut check = F::zero();
     for i in 1..len {
         if eval_at == check {
@@ -320,5 +320,11 @@ mod test {
         let query = F::rand(&mut prng);
 
         assert_eq!(poly.evaluate(&query), interpolate_uni_poly(&evals, query));
+
+        // test interpolation when we ask for the value at an x-cordinate
+        // we are already passing, i.e. in the range 0 <= x < len(values) - 1
+        let evals = vec![0, 1, 4, 9]
+            .into_iter().map(|i| F::from(i)).collect::<Vec<F>>();
+        assert_eq!(interpolate_uni_poly(&evals, F::from(3)), F::from(9));
     }
 }

--- a/src/ml_sumcheck/protocol/verifier.rs
+++ b/src/ml_sumcheck/protocol/verifier.rs
@@ -132,9 +132,10 @@ impl<F: Field> IPForMLSumcheck<F> {
     }
 }
 
-/// interpolate a uni-variate degree-`p_i.len()-1` polynomial and evaluate this
-/// polynomial at `eval_at`:
-///   \sum_{i=0}^len p_i * (\prod_{j!=i} (eval_at - j)/(i-j))
+/// interpolate the *unique* univariate polynomial of degree *at most* 
+/// p_i.len()-1 passing through the y-values in p_i at x = 0,..., p_i.len()-1 
+/// and evaluate this  polynomial at `eval_at`. In other words, efficiently compute
+///  \sum_{i=0}^{len p_i - 1} p_i[i] * (\prod_{j!=i} (eval_at - j)/(i-j))
 pub(crate) fn interpolate_uni_poly<F: Field>(p_i: &[F], eval_at: F) -> F {
     let len = p_i.len();
 

--- a/src/ml_sumcheck/protocol/verifier.rs
+++ b/src/ml_sumcheck/protocol/verifier.rs
@@ -143,12 +143,24 @@ pub(crate) fn interpolate_uni_poly<F: Field>(p_i: &[F], eval_at: F) -> F {
     let mut prod = eval_at;
     evals.push(eval_at);
 
-    // `prod = \prod_{j} (eval_at - j)`
-    for e in 1..len {
-        let tmp = eval_at - F::from(e as u64);
+    //`prod = \prod_{j} (eval_at - j)`
+    // we return early if 0 <= eval_at <  len
+    let mut check = F::zero();
+    for i in 1..len {
+        if eval_at == check {
+            return p_i[i - 1];
+        }
+        check += F::one();
+
+        let tmp = eval_at - check;
         evals.push(tmp);
         prod *= tmp;
     }
+
+    if eval_at == check {
+        return p_i[len - 1];
+    }
+
     let mut res = F::zero();
     // we want to compute \prod (j!=i) (i-j) for a given i
     //

--- a/src/ml_sumcheck/protocol/verifier.rs
+++ b/src/ml_sumcheck/protocol/verifier.rs
@@ -132,8 +132,8 @@ impl<F: Field> IPForMLSumcheck<F> {
     }
 }
 
-/// interpolate the *unique* univariate polynomial of degree *at most* 
-/// p_i.len()-1 passing through the y-values in p_i at x = 0,..., p_i.len()-1 
+/// interpolate the *unique* univariate polynomial of degree *at most*
+/// p_i.len()-1 passing through the y-values in p_i at x = 0,..., p_i.len()-1
 /// and evaluate this  polynomial at `eval_at`. In other words, efficiently compute
 ///  \sum_{i=0}^{len p_i - 1} p_i[i] * (\prod_{j!=i} (eval_at - j)/(i-j))
 pub(crate) fn interpolate_uni_poly<F: Field>(p_i: &[F], eval_at: F) -> F {
@@ -325,7 +325,9 @@ mod test {
         // test interpolation when we ask for the value at an x-cordinate
         // we are already passing, i.e. in the range 0 <= x < len(values) - 1
         let evals = vec![0, 1, 4, 9]
-            .into_iter().map(|i| F::from(i)).collect::<Vec<F>>();
+            .into_iter()
+            .map(|i| F::from(i))
+            .collect::<Vec<F>>();
         assert_eq!(interpolate_uni_poly(&evals, F::from(3)), F::from(9));
     }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

The verifier (file: src/ml_sumcheck/protocol/verifier.rs) contains a function (interpolate_uni_poly) which interpolates the unique polynomial of degree at most d passing through the points (0, y_0), (1, y_2), ..., (d, y_d); and returns the value of the interpolated polynomial at x = eval_at given as an argument.

In the pre-existing implementation, this function would crash if 0 <= eval_at <= d. In practice, eval_at is a challenge point generated pseudo-randomly by the verifier and so the problematic case could indeed be triggered.

The modified code now includes the check 0 <= eval_at <= d, returning y_eval_at if that is the case. The new checks come at essentially no performance cost (verified with a large example). A case has been added at the end of the unit test in the verifier.rs file which failed to pass with the previous code and passes with the modified one.

Furthermore, a slight inaccuracy has been corrected in the former description of the function: the returned polynomial does not necessarily have degree d, but  at most d (and is unique with this property).

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer